### PR TITLE
水）socket-error handling typo

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,7 +82,7 @@ export async function apply(ctx: Context, cfg: Config) {
     password: cfg.RCON.rconPassword,
   });
   const client = net.createConnection(cfg.socket.socketServerPort, cfg.socket.socketServerHost);
-  let sendChannel = cfg.sendToChannel;// ['onebot:737352767'];
+  let sendChannel = cfg.sendToChannel;
   // 监听连接建立事件
   client.on('connect', () => {
     // 发送数据到服务端

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -129,7 +129,7 @@ export async function apply(ctx: Context, cfg: Config) {
       ctx.broadcast(sendChannel,'Socket断开连接！',false)
   })
 
-  ctx.on('minecraft-sync-msg/socket-disconnect',(err)=>{
+  ctx.on('minecraft-sync-msg/socket-error',(err)=>{
     if (err) 
       ctx.broadcast(sendChannel,'Socket连接失败,请重启插件!',false)
   })


### PR DESCRIPTION
还有问一下，logger具体是怎么炸的？（
可以将启动socket并绑定监听做成一个async function，然后接到disconn就再次new。
错误，，，如果是（能判断服务器关机，或网络不稳定）错误断开，就隔10s重连(这么炸的？
那加个变量，如果已经在重连了就发debug或不发
最好可能预先注册koishi的事件(?)